### PR TITLE
BAH-1809 | Remove database root credentials from OpenMRS configuration

### DIFF
--- a/bahmni-emr/package/helm/templates/configMap.yaml
+++ b/bahmni-emr/package/helm/templates/configMap.yaml
@@ -6,8 +6,6 @@ data:
   DB_AUTO_UPDATE: "{{ .Values.config.DB_AUTO_UPDATE }}"
   DB_CREATE_TABLES: "{{ .Values.config.DB_CREATE_TABLES }}"
   DB_DATABASE: "{{ .Values.config.DB_NAME }}"
-  LOAD_DEMO_DATA: "{{ .Values.config.LOAD_DEMO_DATA }}"
-  DB_DUMP_GZIP_URL: "{{ .Values.config.DB_DUMP_GZIP_URL }}"
   DEBUG: "{{ .Values.config.DEBUG }}"
   MODULE_WEB_ADMIN: "{{ .Values.config.MODULE_WEB_ADMIN }}"
   OPENELIS_HOST: "{{ .Values.config.OPENELIS_HOST }}"

--- a/bahmni-emr/package/helm/templates/secrets.yaml
+++ b/bahmni-emr/package/helm/templates/secrets.yaml
@@ -5,8 +5,6 @@ metadata:
 type: Opaque
 data:
   DB_HOST: {{ .Values.secrets.DB_HOST | b64enc | quote }}
-  DB_ROOT_USERNAME: {{ .Values.secrets.DB_ROOT_USERNAME | b64enc | quote }}
-  DB_ROOT_PASSWORD: {{ .Values.secrets.DB_ROOT_PASSWORD | b64enc | quote }}
   DB_USERNAME: {{ .Values.secrets.DB_USERNAME | b64enc | quote }}
   DB_PASSWORD: {{ .Values.secrets.DB_PASSWORD | b64enc | quote }}
   OPENELIS_ATOMFEED_USER: {{ .Values.secrets.OPENELIS_ATOMFEED_USER | b64enc | quote }}

--- a/bahmni-emr/package/helm/values.yaml
+++ b/bahmni-emr/package/helm/values.yaml
@@ -15,10 +15,8 @@ service:
 
 config:
   DB_AUTO_UPDATE: true
-  DB_CREATE_TABLES: false
+  DB_CREATE_TABLES: true
   DB_NAME: openmrs
-  LOAD_DEMO_DATA: true
-  DB_DUMP_GZIP_URL: ''
   DEBUG: false
   MODULE_WEB_ADMIN: false
   OPENELIS_HOST: openelis
@@ -26,8 +24,6 @@ config:
 
 secrets:
   DB_HOST: ""
-  DB_ROOT_USERNAME: ""
-  DB_ROOT_PASSWORD: ""
   DB_USERNAME: ""
   DB_PASSWORD: ""
   OPENELIS_ATOMFEED_USER: ""


### PR DESCRIPTION
- Removes database root credentials from OpenMRS helm configuration
- Removes variables relating to demo data dump.

After this the default configuration would start from a fresh database instead of loading demo data. Also any migrations from `clinic-config` would not be executed as database schema will be created only after OpenMRS boot up.
