### PR TITLE
BAH 2323 | Enable JVM metrics in Bahmni Grafana/Prometheus

### DIFF
--- a/bahmni-emr/package/helm/templates/service.yaml
+++ b/bahmni-emr/package/helm/templates/service.yaml
@@ -13,6 +13,10 @@ spec:
       targetPort: 8080
       protocol: TCP
       name: '8080'
+    - port: 8280
+      targetPort: 8280
+      protocol: TCP
+      name: '8280'
   selector:
     app: {{ .Chart.Name }}
     environment: {{ .Values.metadata.labels.environment }}

--- a/bahmni-emr/package/helm/templates/service.yaml
+++ b/bahmni-emr/package/helm/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
       targetPort: 8080
       protocol: TCP
       name: '8080'
-    - port: 8280
+    - port: {{ .Values.service.jmxport }}
       targetPort: 8280
       protocol: TCP
       name: '8280'

--- a/bahmni-emr/package/helm/values.yaml
+++ b/bahmni-emr/package/helm/values.yaml
@@ -18,6 +18,7 @@ image:
 service:
   type: ClusterIP
   port: 8080
+  jmxport: 8280
 
 config:
   DB_AUTO_UPDATE: true


### PR DESCRIPTION
[JIRA link](https://bahmni.atlassian.net/browse/BAH-2323?atlOrigin=eyJpIjoiMzU5YTcxZWMyNDVkNGUyNTg1NmU3OGMwODYyNzUzMzgiLCJwIjoiaiJ9)

Summary - Expose port 8280 to fetch JVM metrics