### PR TITLE
BAH-2836 | Refactor OpenMRS Docker build

### DIFF
--- a/bahmni-emr/package/docker/Dockerfile
+++ b/bahmni-emr/package/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM bahmni/openmrs:latest
 
-COPY bahmni-emr/resources/*.omod ${OPENMRS_APPLICATION_DATA_DIRECTORY}/modules/
+COPY bahmni-emr/resources/hipmodule*.omod ${OPENMRS_APPLICATION_DATA_DIRECTORY}/modules/
 
 


### PR DESCRIPTION
OpenMRS Docker build process to clearly state the names of OMODs being copied instead of using a wildcard (*). This will improve transparency and accountability in the build process and make it easier to track changes.